### PR TITLE
openobserve-collector: Add K8S_NODE_IP envs

### DIFF
--- a/charts/openobserve-collector/templates/agent.yaml
+++ b/charts/openobserve-collector/templates/agent.yaml
@@ -14,6 +14,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
   {{- with .Values.agent.tolerations }}
   tolerations:
     {{- toYaml . | nindent 8 }}

--- a/charts/openobserve-collector/templates/gateway.yaml
+++ b/charts/openobserve-collector/templates/gateway.yaml
@@ -22,6 +22,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
   {{- with .Values.gateway.tolerations }}
   tolerations:
     {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
On some cluster configurations nodes cannot be resolved by name. This causes connection issues on opentelemetry collector agents as reported here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26481

We are facing the same issue with openobserve-collector on a managed k8s instance:
```sh
$ kubectl logs -n openobserve openobserve-collector-agent-collector-29zmg
2025-08-23T08:49:05.189Z        error   scraperhelper@v0.127.0/obs_metrics.go:61        Error scraping metrics  {"resource": {}, "otelcol.component.id": "kubeletstats", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics", "error": "Get \"https://staging-2fkxr:10250/stats/summary\": dial tcp: lookup staging-2fkxr on 10.245.0.10:53: no such host"}
```

This PR exposes the K8S_NODE_IP environment variable so that [this](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26481#issuecomment-1720797914) workaround can be applied on affected cluster configurations.