### PR TITLE
feat: add imagePullSecrets support for openobserve-collector chart (#187)

### DIFF
--- a/charts/openobserve-collector/templates/agent.yaml
+++ b/charts/openobserve-collector/templates/agent.yaml
@@ -9,6 +9,10 @@ spec:
   mode: daemonset # "daemonset", "deployment" (default), "statefulset"
   serviceAccount: {{ include "openobserve-collector.serviceAccountName" . }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+  {{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   env:
     - name: K8S_NODE_NAME
       valueFrom:

--- a/charts/openobserve-collector/templates/gateway.yaml
+++ b/charts/openobserve-collector/templates/gateway.yaml
@@ -28,6 +28,10 @@ spec:
   {{- end }}
   serviceAccount: {{ include "openobserve-collector.serviceAccountName" . }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+  {{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   env:
     - name: K8S_NODE_NAME
       valueFrom:

--- a/charts/openobserve-collector/values.yaml
+++ b/charts/openobserve-collector/values.yaml
@@ -20,6 +20,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.138.0"
+  imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
 ## Feature Request
   Fixes #187 - Add `imagePullSecrets` support to `openobserve-collector` chart to allow pulling images from private registries.

   ## Changes
   - Added `imagePullSecrets: []` configuration in `values.yaml` under `image` section
   - Added `imagePullSecrets` field in `agent.yaml` template for Agent DaemonSet
   - Added `imagePullSecrets` field in `gateway.yaml` template for Gateway StatefulSet

   ## Use Case
   When using a private registry, users can now configure `imagePullSecrets` in their values:
  image:
    imagePullSecrets:
       - name: my-registry-secret

   ## Impact
   - ✅ Enables deployment with private container registries
   - ✅ Aligns with existing `openobserve` and `openobserve-standalone` charts
   - ✅ Maintains backward compatibility - default is empty array (no secrets)
