### PR TITLE
fix: remove master encryption algo default value

### DIFF
--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -560,7 +560,7 @@ enterprise:
     O2_AI_ENABLED: "false"
     O2_AGENT_URL: ""  # Leave empty to use default auto-generated URL
     O2_TOOL_API_URL: ""  # Leave empty to use default auto-generated URL
-    ZO_MASTER_ENCRYPTION_ALGORITHM: "aes-256-siv"
+    ZO_MASTER_ENCRYPTION_ALGORITHM: "" # MUST be empty if key is empty
     ZO_MASTER_ENCRYPTION_KEY: ""
     # Service Graph features
     O2_SERVICE_GRAPH_ENABLED: "false"

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -901,7 +901,7 @@ enterprise:
     O2_AI_ENABLED: "false"
     O2_AGENT_URL: ""  # Leave empty to use default auto-generated URL
     O2_TOOL_API_URL: ""  # Leave empty to use default auto-generated URL
-    ZO_MASTER_ENCRYPTION_ALGORITHM: "aes-256-siv"
+    ZO_MASTER_ENCRYPTION_ALGORITHM: "" # MUST be empty if key is empty
     ZO_MASTER_ENCRYPTION_KEY: ""
     # Service Graph features
     O2_SERVICE_GRAPH_ENABLED: "false"


### PR DESCRIPTION
if algo is set but key is empty, it will crash the node with config validation error. It MUST be empty is key is not set