### PR TITLE
fix: remove merge conflict markers in collector agent and gateway tem…

### DIFF
--- a/charts/openobserve-collector/templates/agent.yaml
+++ b/charts/openobserve-collector/templates/agent.yaml
@@ -12,13 +12,12 @@ spec:
   mode: daemonset # "daemonset", "deployment" (default), "statefulset"
   serviceAccount: {{ include "openobserve-collector.serviceAccountName" . }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-<<<<<<< feat/collector-workload-identity-support
-  {{- with .Values.agent.podAnnotations }}
-  podAnnotations:
-=======
   {{- with .Values.image.imagePullSecrets }}
   imagePullSecrets:
->>>>>>> main
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.agent.podAnnotations }}
+  podAnnotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   env:

--- a/charts/openobserve-collector/templates/gateway.yaml
+++ b/charts/openobserve-collector/templates/gateway.yaml
@@ -31,13 +31,12 @@ spec:
   {{- end }}
   serviceAccount: {{ include "openobserve-collector.serviceAccountName" . }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-<<<<<<< feat/collector-workload-identity-support
-  {{- with .Values.gateway.podAnnotations }}
-  podAnnotations:
-=======
   {{- with .Values.image.imagePullSecrets }}
   imagePullSecrets:
->>>>>>> main
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gateway.podAnnotations }}
+  podAnnotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   env:


### PR DESCRIPTION


Conflict markers were committed to main, breaking helm template/install. Resolved by keeping both imagePullSecrets and podAnnotations blocks in the correct order.