### PR TITLE
feat: Add manual Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-manual-review.yml
+++ b/.github/workflows/claude-manual-review.yml
@@ -1,0 +1,101 @@
+name: Claude Manual PR Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+
+env:
+  REVIEW_MARKER: "<!-- claude-pr-review -->"
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Get PR details
+        id: pr
+        run: |
+          PR_DATA=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json headRefName,headRepository,headRepositoryOwner,number,headRefOid)
+          echo "head_ref=$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+          echo "head_sha=$(echo $PR_DATA | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
+          echo "head_repo=$(echo $PR_DATA | jq -r '.headRepository.nameWithOwner')" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: PR Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ inputs.pr_number }}
+
+            ## CRITICAL: ONE COMMENT ONLY
+
+            You must post EXACTLY ONE comment on this PR. Never post multiple comments.
+            Never post a summary AND a review - combine everything into ONE comment.
+
+            ### Step 1: Check for Existing Review
+
+            Run: `gh pr view ${{ inputs.pr_number }} --json comments --jq '.comments[] | select(.body | contains("<!-- claude-pr-review -->")) | .id'`
+
+            ### Step 2: Review the Code
+
+            Run: `gh pr diff ${{ inputs.pr_number }}`
+
+            Focus on bugs, security issues, and performance problems only.
+            Skip style suggestions, documentation, and "nice to have" improvements.
+
+            ### Step 3: Post or Update Comment
+
+            **If existing comment found (Step 1 returned an ID):**
+            Use `gh api` to update it:
+            ```
+            gh api repos/${{ github.repository }}/issues/comments/{COMMENT_ID} -X PATCH -f body='...'
+            ```
+
+            **If no existing comment:**
+            Create one: `gh pr comment ${{ inputs.pr_number }} --body '...'`
+
+            ### Comment Format (EXACT FORMAT - NO ADDITIONS)
+
+            ```
+            <!-- claude-pr-review -->
+            ## Code Review
+
+            **Status:** [X issues / LGTM ✅] | **Commit:** [short SHA]
+
+            | File | Issue | Severity |
+            |------|-------|----------|
+            | `file:line` | Brief description. Fix: suggestion | High/Med/Low |
+
+            ### Resolved
+            - ~~Fixed issue~~
+            ```
+
+            ### STRICT RULES
+
+            - **ONE comment only** - never post multiple comments
+            - **No summaries** - no "Review Complete", no "Security Assessment", no highlights
+            - **No praise** - no "excellent", "strong", "great work" sections
+            - **2 sentences max** per issue
+            - **Max 10 issues** - prioritize by severity
+            - **LGTM if clean** - just show "Status: LGTM ✅" with empty table
+
+          claude_args: |
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Read,Grep,Glob"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,7 +8,7 @@ env:
   REVIEW_MARKER: "<!-- claude-pr-review -->"
 
 jobs:
-  review-with-tracking:
+  claude-review:
     runs-on: ubuntu-latest
     # Only run when 'claude-review' label is added (for security)
     if: github.event.label.name == 'claude-review' || contains(github.event.pull_request.labels.*.name, 'claude-review')
@@ -24,11 +24,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Full history needed to check what changed
 
-      - name: PR Review with Progress Tracking
+      - name: PR Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
 
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,8 +1,8 @@
 name: Claude PR Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  pull_request_target:
+    types: [labeled, synchronize, ready_for_review, reopened]
 
 env:
   REVIEW_MARKER: "<!-- claude-pr-review -->"
@@ -10,6 +10,8 @@ env:
 jobs:
   review-with-tracking:
     runs-on: ubuntu-latest
+    # Only run when 'claude-review' label is added (for security)
+    if: github.event.label.name == 'claude-review' || contains(github.event.pull_request.labels.*.name, 'claude-review')
     permissions:
       contents: read
       pull-requests: write
@@ -19,6 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Full history needed to check what changed
 
       - name: PR Review with Progress Tracking


### PR DESCRIPTION
## Overview
Adds a manually-triggered workflow for Claude code reviews that works with fork PRs.

## Changes
1. **New workflow**: `.github/workflows/claude-manual-review.yml`
   - Triggered manually via GitHub UI or CLI
   - Accepts PR number as input
   - Works with both fork and internal PRs
   - No OIDC or event compatibility issues

2. **Updated workflow**: `.github/workflows/claude-pr-review.yml`
   - Fixed for fork PRs with label trigger
   - Removed `track_progress` incompatibility

## Usage

### Via GitHub UI:
1. Go to Actions tab
2. Select "Claude Manual PR Review"
3. Click "Run workflow"
4. Enter PR number (e.g., 158)

### Via CLI:
```bash
gh workflow run claude-manual-review.yml --repo openobserve/openobserve-helm-chart -f pr_number=158
```

## Benefits
- ✅ Works with fork PRs
- ✅ No OIDC authentication issues
- ✅ Complete maintainer control
- ✅ Simpler and more reliable