### PR TITLE
feat: add optional ServiceMonitor to the openobserve-standalone chart

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-standalone/README.md
+++ b/charts/openobserve-standalone/README.md
@@ -202,6 +202,22 @@ gateway:
 
 **Important**: For standalone deployments, ensure the `backendRefs.name` matches your actual service name (typically `{{ release-name }}-openobserve-standalone`).
 
+# Monitoring (Prometheus Operator)
+
+If you run the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), you can let it scrape OpenObserve's own `/metrics` endpoint by enabling a `ServiceMonitor`. It is disabled by default:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  # interval: 30s
+  # scrapeTimeout: 10s
+  # Add labels so your Prometheus serviceMonitorSelector picks it up, e.g.:
+  # labels:
+  #   release: kube-prometheus-stack
+```
+
+The `ServiceMonitor` selects the standalone Service and scrapes the `http` port at `/metrics`. Note that `/metrics` is blocked for **public** access when `ingress`/`gateway` is enabled — the `ServiceMonitor` scrapes the in-cluster Service directly, so it is unaffected by that block. Requires the `monitoring.coreos.com/v1` CRDs to be installed.
+
 # Development
 
 If you are developing this chart then you should clone the repo and make any modifications.

--- a/charts/openobserve-standalone/templates/servicemonitor.yaml
+++ b/charts/openobserve-standalone/templates/servicemonitor.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openobserve.fullname" . }}
+  {{- with .Values.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
+  labels:
+    {{- include "openobserve.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ . | quote }}
+  {{- end }}
+  # Select the standalone Service (the headless Service does not carry the
+  # prometheus.io/scrape label, so it is intentionally excluded).
+  selector:
+    matchLabels:
+      {{- include "openobserve.selectorLabels" . | nindent 6 }}
+      prometheus.io/scrape: "true"
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: {{ .Values.serviceMonitor.port | default "http" | quote }}
+      path: {{ .Values.serviceMonitor.path | default "/metrics" | quote }}
+      scheme: {{ .Values.serviceMonitor.scheme | default "http" | quote }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.basicAuth }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.bearerTokenSecret }}
+      bearerTokenSecret:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -338,6 +338,37 @@ service:
   # grpc_nodePort: 30581
   annotations: {}
 
+# Prometheus Operator ServiceMonitor for scraping OpenObserve's own /metrics endpoint.
+# Requires the Prometheus Operator CRDs (monitoring.coreos.com/v1) to be installed.
+# NOTE: /metrics and /api/metrics are blocked for PUBLIC access when ingress/gateway is
+# enabled (see ingress/gateway above). The ServiceMonitor scrapes the in-cluster Service
+# directly, so it is unaffected by that public block.
+serviceMonitor:
+  enabled: false
+  # Namespace to deploy the ServiceMonitor into. Defaults to the release namespace.
+  namespace: ""
+  # Additional labels for the ServiceMonitor (e.g. to match your Prometheus serviceMonitorSelector).
+  labels: {}
+  # Additional annotations for the ServiceMonitor.
+  annotations: {}
+  # Service port name to scrape (must match the Service port name).
+  port: http
+  # Metrics path exposed by OpenObserve.
+  path: /metrics
+  scheme: http
+  interval: 30s
+  scrapeTimeout: 10s
+  honorLabels: false
+  # jobLabel: app.kubernetes.io/name
+  # TLS configuration for scraping (when OpenObserve serves metrics over HTTPS).
+  tlsConfig: {}
+  # basicAuth / bearerTokenSecret for protected /metrics endpoints.
+  basicAuth: {}
+  # bearerTokenSecret: {}
+  # relabelings / metricRelabelings are lists of Prometheus relabel configs.
+  relabelings: []
+  metricRelabelings: []
+
 certIssuer:
   enabled: false
 


### PR DESCRIPTION
Adds an opt-in Prometheus Operator `ServiceMonitor` to the `openobserve-standalone` chart so an existing Prometheus stack can scrape OpenObserve's own `/metrics` endpoint. Disabled by default (`serviceMonitor.enabled=false`) — no change to existing installs.

The standalone Service already carries `prometheus.io/scrape: "true"` and a named `http` port, so the `ServiceMonitor` simply selects it and scrapes `/metrics`. `/metrics` stays blocked for **public** access via ingress/gateway; the `ServiceMonitor` scrapes the in-cluster Service directly, so it is unaffected by that block.

### Validation (helm v3.18.1)
- `helm lint`: 0 failed
- Disabled by default → renders 0 ServiceMonitors
- Enabled → selector matches the standalone Service (`name`/`instance` + `prometheus.io/scrape`), `http` port, `/metrics`
- Custom `namespace`/`labels`/`interval`/`honorLabels` render correctly
- Headless Service correctly excluded (it lacks the scrape label)

### Scope
Standalone chart only, as a first slice. Happy to follow up with the HA `openobserve` chart (per-component services) if you'd like.

related: #186

---

<sub>Implemented with the help of Claude Code (Opus 4.8); reviewed and validated locally by me before opening.</sub>