### PR TITLE
feat: collector : expose securityContext for agent and gateway collectors

### DIFF
--- a/charts/openobserve-collector/Chart.yaml
+++ b/charts/openobserve-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-collector/templates/agent.yaml
+++ b/charts/openobserve-collector/templates/agent.yaml
@@ -33,6 +33,14 @@ spec:
   tolerations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.agent.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.agent.podSecurityContext }}
+  podSecurityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   volumes:
     - name: hostfs
       hostPath:

--- a/charts/openobserve-collector/templates/gateway.yaml
+++ b/charts/openobserve-collector/templates/gateway.yaml
@@ -64,6 +64,14 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.gateway.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gateway.podSecurityContext }}
+  podSecurityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   config:
     receivers:
       {{- toYaml .Values.gateway.receivers | nindent 6 }}

--- a/charts/openobserve-collector/values.yaml
+++ b/charts/openobserve-collector/values.yaml
@@ -106,6 +106,21 @@ agent:
   labels: {}
   # Annotations added to the generated collector pods.
   podAnnotations: {}
+  # securityContext applied to the agent collector container.
+  # Required on OpenShift (and other SELinux-enforcing distros) so the filelog
+  # receiver can read host pod logs under /var/log/pods. Without this the collector
+  # logs "open .: permission denied" and no container logs are collected.
+  # Also grant the privileged SCC to the agent's service account, e.g.:
+  #   oc adm policy add-scc-to-user privileged -z <agent-sa> -n <namespace>
+  # Example:
+  #   securityContext:
+  #     privileged: true
+  #     runAsUser: 0
+  #     seLinuxOptions:
+  #       type: spc_t
+  securityContext: {}
+  # podSecurityContext applied to the agent collector pod.
+  podSecurityContext: {}
   tolerations:
     - operator: Exists
   resources: {}
@@ -369,6 +384,11 @@ gateway:
   labels: {}
   # Annotations added to the generated collector pods.
   podAnnotations: {}
+  # securityContext applied to the gateway collector container (e.g. for OpenShift/SELinux).
+  # See agent.securityContext above for details.
+  securityContext: {}
+  # podSecurityContext applied to the gateway collector pod.
+  podSecurityContext: {}
   # Number of replicas when autoscaler is not used
   replicas: 1
   targetAllocator:


### PR DESCRIPTION
## What
Adds optional `securityContext` and `podSecurityContext` fields to the
`agent` and `gateway` collectors, wired through to the generated
`OpenTelemetryCollector` CRs.

## Why
On OpenShift (and other SELinux-enforcing distros), the agent's filelog
receiver cannot read host pod logs under `/var/log/pods` — the collector
logs `open .: permission denied` and no container logs are collected. The
host path is mounted correctly; the container simply lacks the required
SELinux/privilege context. Because the chart didn't expose
`securityContext`, there was no way to fix this via `values.yaml` short of
a post-renderer or forked template.

## Changes
- `templates/agent.yaml`: `securityContext` + `podSecurityContext` passthrough
- `templates/gateway.yaml`: same
- `values.yaml`: documented `{}` defaults for both collectors

## Backwards compatibility
Defaults are `{}`, guarded by `{{- with }}`, so nothing is rendered unless
explicitly set — no change for existing users.

## Testing
- `helm template` with overrides: `securityContext` renders on both CRs
- `helm template` with defaults: no `securityContext` on either CR
- `helm lint`: passes

## OpenShift usage
```yaml
agent:
  securityContext:
    privileged: true
    runAsUser: 0
    seLinuxOptions:
      type: spc_t
