### PR TITLE
chore: bump openobserve to v0.91.1, upgrade NATS dependency and CNPG operator

### DIFF
--- a/charts/openobserve-standalone/Chart.lock
+++ b/charts/openobserve-standalone/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.min.io
   version: 5.3.0
 digest: sha256:c539f29a4cbdeef50e73fccb320917baf7e08913288b2b2ba68f89f0eaf266de
-generated: "2026-02-05T14:36:31.330341+05:30"
+generated: "2026-07-12T12:17:17.782583+05:30"

--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.80.3
+version: 0.91.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.80.2"
+appVersion: "v0.91.1"
 
 dependencies:
   - name: minio

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -6,17 +6,17 @@ image:
   oss:
     repository: o2cr.ai/openobserve/openobserve
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.80.2"
+    tag: "v0.91.1"
   enterprise:
     repository: o2cr.ai/openobserve/openobserve-enterprise
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.80.2"
+    tag: "v0.91.1"
   busybox:
     repository: public.ecr.aws/docker/library/busybox
     tag: 1.36.1
   o2ai:
     repository: ghcr.io/openobserve/o2-ai
-    tag: "v0.80.1"
+    tag: "v0.91.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/openobserve/Chart.lock
+++ b/charts/openobserve/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 1.3.13
+  version: 2.14.2
 - name: minio
   repository: https://charts.min.io
   version: 5.3.0
-digest: sha256:191a69d17bff1eddb186d797d3ff93e21d8d28a024af20706179bafe31cef042
-generated: "2026-03-04T12:32:35.938509+08:00"
+digest: sha256:a55f05a243ea3850dae02d97712fa2e3d97d3151c846077ce0066b936f4ccf61
+generated: "2026-07-12T12:17:15.265787+05:30"

--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,17 +15,17 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.80.3
+version: 0.91.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.80.2"
+appVersion: "v0.91.1"
 
 dependencies:
   - name: nats
-    version: "1.3.13"
+    version: "2.14.2"
     repository: "https://nats-io.github.io/k8s/helm/charts/"
     condition: nats.enabled
   - name: minio

--- a/charts/openobserve/README.md
+++ b/charts/openobserve/README.md
@@ -16,7 +16,7 @@ You must set a minimum of 2 values:
 Install the Cloud Native PostgreSQL Operator. This is a prerequisite for openobserve helm chart. This helm chart sets up a postgres database cluster (1 primary + 1 replica) and uses it as metadata store of OpenObserve.
 ```shell
 kubectl apply --server-side -f \
-  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.27/releases/cnpg-1.27.1.yaml
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.30/releases/cnpg-1.30.0.yaml
 ```
 
 Install the openobserve helm chart

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -6,11 +6,11 @@ image:
   oss:
     repository: o2cr.ai/openobserve/openobserve
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.80.2"
+    tag: "v0.91.1"
   enterprise:
     repository: o2cr.ai/openobserve/openobserve-enterprise
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.80.2"
+    tag: "v0.91.1"
   reportserver:
     repository: o2cr.ai/openobserve/report-server
     tag: "v0.11.2-88574bc"
@@ -19,7 +19,7 @@ image:
     tag: 1.36.1
   o2ai:
     repository: ghcr.io/openobserve/o2-ai
-    tag: "v0.80.1"
+    tag: "v0.91.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -722,9 +722,9 @@ nats:
     cluster:
       enabled: true
       replicas: 3
-    routeURLs:
-      user: ""
-      password: ""
+      routeURLs:
+        user: ""
+        password: ""
     jetstream:
       enabled: true
       fileStore:
@@ -733,15 +733,15 @@ nats:
           enabled: true
           size: 20Gi
           storageClassName: ""
-    promExporter:
+  promExporter:
+    enabled: true
+    podMonitor:
       enabled: true
-      podMonitor:
-        enabled: true
   natsBox:
     container:
       image:
         repository: natsio/nats-box
-        tag: 0.18.0-nonroot
+        tag: 0.19.7
 
 minio:
   enabled: false # if true then minio will be deployed as part of openobserve
@@ -778,7 +778,7 @@ minio:
 # Make sure to install cloudnative-pg operator before enabling this
 # https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/installation_upgrade.md
 # kubectl apply --server-side -f \
-#   https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.27/releases/cnpg-1.27.1.yaml
+#   https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.30/releases/cnpg-1.30.0.yaml
 postgres:
   enabled: true
   pgadmin:
@@ -799,7 +799,7 @@ postgres:
     password: Batman123 # password # username is hardcoded to openobserve, db is hardcoded to app
     enableSuperuserAccess: true # if true then superuser access will be enabled. You can get the password from appropriate secret once the postgres is deployed
     instances: 2 # creates a primary and a replica. replica will become primary if the primary fails
-    affinity: # see details https://cloudnative-pg.io/documentation/1.27/scheduling/
+    affinity: # see details https://cloudnative-pg.io/docs/1.30/scheduling/
       podAntiAffinityType: preferred
     storage:
       size: 10Gi
@@ -809,7 +809,7 @@ postgres:
         max_connections: "1500"
     monitoring:
       enablePodMonitor: true
-    backup: {} # All the configuration associated with an object store from https://cloudnative-pg.io/documentation/1.27/backup_recovery/
+    backup: {} # All the configuration associated with an object store from https://cloudnative-pg.io/docs/1.30/backup/
 
 enterprise:
   enabled: true
@@ -1026,21 +1026,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   compactor:
     enabled: false
@@ -1050,21 +1050,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   ingester:
     enabled: false
@@ -1074,21 +1074,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 1200 # 20 minutes for now, since we are using pre-stop hook to flush data and it takes up to 10 minutes to flush data to s3
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 1200 # 20 minutes for now, since we are using pre-stop hook to flush data and it takes up to 10 minutes to flush data to s3
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 1200 # 20 minutes for now, since we are using pre-stop hook to flush data and it takes up to 10 minutes to flush data to s3
   querier:
     enabled: false
@@ -1098,21 +1098,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   alertquerier:
     enabled: false
@@ -1122,21 +1122,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   router:
     enabled: true
@@ -1146,21 +1146,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   dex:
     enabled: false
@@ -1170,21 +1170,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30  
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30  
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   openfga:
     enabled: false
@@ -1194,21 +1194,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   reportserver:
     enabled: false
@@ -1218,21 +1218,21 @@ probes:
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       readinessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
       livenessProbe:
         initialDelaySeconds: 10
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 30
         terminationGracePeriodSeconds: 30
   o2ai:
     enabled: true


### PR DESCRIPTION
bump openobserve to v0.91.1, upgrade NATS dependency and CNPG operator

- Bump openobserve to v0.91.1 (charts + image tags)
- Upgrade NATS Helm chart from 1.3.13 to 2.14.2 (appVersion: 2.14.2)
- Fix misplaced NATS values: routeURLs moved under config.cluster, promExporter moved to top-level
- Update nats-box image tag to 0.19.7
- Update CNPG operator references from 1.27.1 to 1.30.0
- Fix CNPG docs URLs (/documentation/ -> /docs/)
- Increase probe failureThreshold from 3 to 30 for all components