### PR TITLE
fix(collector): always set managementState on OpenTelemetryCollector CRs

### DIFF
--- a/charts/openobserve-collector/Chart.yaml
+++ b/charts/openobserve-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5
+version: 0.4.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-collector/templates/agent.yaml
+++ b/charts/openobserve-collector/templates/agent.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     {{- toYaml $agentLabels | nindent 4 }}
 spec:
+  # Explicitly set so the collector renders on opentelemetry-operator versions whose
+  # v1beta1 CRD requires spec.managementState (otherwise install/ArgoCD validation fails
+  # with: missing required field "managementState"). See #108, #129, #141.
+  managementState: {{ .Values.managementState | default "managed" }}
   mode: daemonset # "daemonset", "deployment" (default), "statefulset"
   serviceAccount: {{ include "openobserve-collector.serviceAccountName" . }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/openobserve-collector/templates/gateway.yaml
+++ b/charts/openobserve-collector/templates/gateway.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     {{- toYaml $gatewayLabels | nindent 4 }}
 spec:
+  # Explicitly set so the collector renders on opentelemetry-operator versions whose
+  # v1beta1 CRD requires spec.managementState (otherwise install/ArgoCD validation fails
+  # with: missing required field "managementState"). See #108, #129, #141.
+  managementState: {{ .Values.managementState | default "managed" }}
   {{- if .Values.gateway.autoscaler }}
   autoscaler:
     {{- toYaml .Values.gateway.autoscaler | nindent 4 }}

--- a/charts/openobserve-collector/values.yaml
+++ b/charts/openobserve-collector/values.yaml
@@ -15,6 +15,12 @@ exporters:
 
 k8sCluster: "cluster1"
 
+# managementState for the OpenTelemetryCollector CRs (agent & gateway).
+# "managed" (default) lets the opentelemetry-operator reconcile the collector.
+# Some operator versions require this field to be present on the v1beta1 CRD, so it
+# is always rendered. Set to "unmanaged" to have the operator stop reconciling.
+managementState: "managed"
+
 image:
   repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Some opentelemetry-operator versions require `spec.managementState` on the v1beta1 `OpenTelemetryCollector` CRD. Without it, install/ArgoCD validation fails with `missing required field "managementState"`.

Renders it explicitly on both the agent and gateway CRs, driven by a new top-level `managementState` value (default `managed`).

Verified with `helm template` on the collector chart.

Fixes #108
Fixes #129
Fixes #141