### PR TITLE
fix(blocked-metrics): make nginx container resources configurable

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-standalone/templates/blocked-metrics-deployment.yaml
+++ b/charts/openobserve-standalone/templates/blocked-metrics-deployment.yaml
@@ -44,12 +44,7 @@ spec:
         - name: run
           mountPath: /var/run
         resources:
-          requests:
-            cpu: 10m
-            memory: 16Mi
-          limits:
-            cpu: 50m
-            memory: 32Mi
+          {{- toYaml .Values.blockedMetrics.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -344,6 +344,19 @@ certIssuer:
 secret:
   annotations: {}
 
+# blocked-metrics is a small nginx sidecar deployed when ingress is enabled (and the
+# gateway is not) to block public access to the /metrics endpoints.
+blockedMetrics:
+  # Resources for the blocked-metrics nginx container. Exposed because the previous
+  # hardcoded 32Mi limit could OOMKill the container in some environments.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 128Mi
+
 ingress:
   enabled: false
   className: "nginx"

--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve/templates/blocked-metrics-deployment.yaml
+++ b/charts/openobserve/templates/blocked-metrics-deployment.yaml
@@ -44,12 +44,7 @@ spec:
         - name: run
           mountPath: /var/run
         resources:
-          requests:
-            cpu: 10m
-            memory: 16Mi
-          limits:
-            cpu: 50m
-            memory: 32Mi
+          {{- toYaml .Values.blockedMetrics.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -498,6 +498,19 @@ serviceIngester:
 certIssuer:
   enabled: false
 
+# blocked-metrics is a small nginx sidecar deployed when ingress is enabled (and the
+# gateway is not) to block public access to the /metrics endpoints.
+blockedMetrics:
+  # Resources for the blocked-metrics nginx container. Exposed because the previous
+  # hardcoded 32Mi limit could OOMKill the container in some environments.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 128Mi
+
 ingress:
   enabled: false
   className: "nginx"


### PR DESCRIPTION
The blocked-metrics nginx container had hardcoded resource limits (memory 32Mi), which could OOMKill it into CrashLoopBackOff.

Exposes resources via a new `blockedMetrics.resources` value in both the `openobserve` and `openobserve-standalone` charts, and raises the default memory limit to 128Mi.

Supersedes the stale `copilot/update-nginx-memory-limits` branch.

Fixes #183