### PR TITLE
fix(standalone): honor persistence.enabled for the data volume

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
+++ b/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
@@ -125,12 +125,22 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if not .Values.persistence.enabled }}
+        # persistence disabled: back /data with an ephemeral emptyDir instead of a PVC.
+        - name: data
+          emptyDir: {}
+      {{- end }}
       {{- if .Values.extraVolumes }}
       {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
+  {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: data
+      {{- with .Values.persistence.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       accessModes:
       {{- range .Values.persistence.accessModes }}
@@ -140,3 +150,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.persistence.size | quote }}
+  {{- end }}


### PR DESCRIPTION
Previously the data `volumeClaimTemplate` was always rendered, so `persistence.enabled: false` had no effect on the volume backing `/data` — it only gated the `volumePermissions` init container.

Now gates the `volumeClaimTemplate` behind `persistence.enabled` and falls back to an ephemeral `emptyDir` `data` volume when disabled. Also honors `persistence.annotations` on the PVC template.

Verified: `helm template --set persistence.enabled=false` renders no `volumeClaimTemplates` and backs `/data` with an `emptyDir`.

Fixes #220