### PR TITLE
feat(openfga): support nodeSelector, affinity and tolerations

### DIFF
--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve/templates/openfga-deployment.yaml
+++ b/charts/openobserve/templates/openfga-deployment.yaml
@@ -48,6 +48,18 @@ spec:
               cpu: 100m
               memory: 128Mi
             {{- end }}
+      {{- with .Values.nodeSelector.openfga }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity.openfga }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations.openfga }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: openfga
           image: {{ .Values.enterprise.openfga.image.repository }}:{{ .Values.enterprise.openfga.image.tag }}

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -692,6 +692,7 @@ nodeSelector:
   dex: {}
   reportserver: {}
   o2ai: {}
+  openfga: {}
 
 tolerations:
   ingester: []
@@ -703,6 +704,7 @@ tolerations:
   dex: []
   reportserver: []
   o2ai: []
+  openfga: []
 
 affinity:
   ingester: {}
@@ -714,6 +716,7 @@ affinity:
   dex: {}
   reportserver: {}
   o2ai: {}
+  openfga: {}
 
 nats:
   enabled: true # if true then nats will be deployed as part of openobserve


### PR DESCRIPTION
The openfga deployment had no scheduling controls, unlike every other workload in the chart (including `o2ai`).

Adds `nodeSelector`/`affinity`/`tolerations` blocks driven from values, with new `openfga` keys.

Fixes #166