### PR TITLE
fix(ingress): don't hardcode cert-manager issuer annotation

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-standalone/templates/ingress.yaml
+++ b/charts/openobserve-standalone/templates/ingress.yaml
@@ -19,9 +19,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openobserve.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if or .Values.ingress.annotations .Values.certIssuer.enabled }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.certIssuer.enabled }}
+    cert-manager.io/issuer: letsencrypt
+    {{- end }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -349,7 +349,9 @@ ingress:
   className: "nginx"
   # NOTE: /metrics and /api/metrics endpoints are always blocked for public access when ingress is enabled
   annotations:
-    cert-manager.io/issuer: letsencrypt
+    # NOTE: the cert-manager.io/issuer annotation is NOT set here. It is injected
+    # automatically by the ingress template when certIssuer.enabled=true. This lets you
+    # use your own cert-manager.io/cluster-issuer here without a conflicting issuer.
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     # nginx.ingress.kubernetes.io/connection-proxy-header: keep-alive

--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve/templates/ingress.yaml
+++ b/charts/openobserve/templates/ingress.yaml
@@ -19,9 +19,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openobserve.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if or .Values.ingress.annotations .Values.certIssuer.enabled }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.certIssuer.enabled }}
+    cert-manager.io/issuer: letsencrypt
+    {{- end }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -503,7 +503,9 @@ ingress:
   className: "nginx"
   # NOTE: /metrics and /api/metrics endpoints are always blocked for public access when ingress is enabled
   annotations:
-    cert-manager.io/issuer: letsencrypt
+    # NOTE: the cert-manager.io/issuer annotation is NOT set here. It is injected
+    # automatically by the ingress template when certIssuer.enabled=true. This lets you
+    # use your own cert-manager.io/cluster-issuer here without a conflicting issuer.
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1" # Enable HTTP/1.1 for WebSockets


### PR DESCRIPTION
The default `ingress.annotations` hardcoded `cert-manager.io/issuer: letsencrypt`. Users deploying with their own `cert-manager.io/cluster-issuer` ended up with **both** annotations, which cert-manager treats as invalid and ignores — so no certificate was issued.

Removes the hardcoded annotation from the values defaults and injects `cert-manager.io/issuer: letsencrypt` from the ingress template only when `certIssuer.enabled=true` (the built-in Issuer). Applied to both charts.

Documented in `UPGRADING.md` (see #89 PR).

Fixes #60