### PR TITLE
fix(standalone): store ZO_META_POSTGRES_DSN in Secret, add auth override

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-standalone/templates/configmap.yaml
+++ b/charts/openobserve-standalone/templates/configmap.yaml
@@ -42,7 +42,9 @@ data:
   ZO_WEB_URL: "{{ .Values.config.ZO_WEB_URL }}"
   ZO_BASE_URI: "{{ .Values.config.ZO_BASE_URI }}"
   ZO_META_STORE: "{{ .Values.config.ZO_META_STORE }}"
-  ZO_META_POSTGRES_DSN: "{{ .Values.config.ZO_META_POSTGRES_DSN }}"
+  # ZO_META_POSTGRES_DSN is intentionally NOT set here — it is a credential and is
+  # rendered into the Secret instead (see templates/secret.yaml). Set it via
+  # auth.ZO_META_POSTGRES_DSN (preferred) or config.ZO_META_POSTGRES_DSN.
   ZO_META_CONNECTION_POOL_MIN_SIZE: "{{ .Values.config.ZO_META_CONNECTION_POOL_MIN_SIZE }}"
   ZO_META_CONNECTION_POOL_MAX_SIZE: "{{ .Values.config.ZO_META_CONNECTION_POOL_MAX_SIZE }}"
   ZO_META_TRANSACTION_RETRIES: "{{ .Values.config.ZO_META_TRANSACTION_RETRIES }}"

--- a/charts/openobserve-standalone/templates/secret.yaml
+++ b/charts/openobserve-standalone/templates/secret.yaml
@@ -25,6 +25,11 @@ stringData:
   {{- else }}
   ZO_S3_SECRET_KEY: "{{ .Values.minio.rootPassword }}"
   {{- end }}
+  {{- if .Values.auth.ZO_META_POSTGRES_DSN }}
+  ZO_META_POSTGRES_DSN: "{{ .Values.auth.ZO_META_POSTGRES_DSN }}"
+  {{- else if .Values.config.ZO_META_POSTGRES_DSN }}
+  ZO_META_POSTGRES_DSN: "{{ .Values.config.ZO_META_POSTGRES_DSN }}"
+  {{- end }}
   {{- if eq .Values.config.ZO_S3_PROVIDER "azure" }}
   {{- if .Values.auth.AZURE_STORAGE_ACCOUNT_KEY }}
   AZURE_STORAGE_ACCOUNT_KEY: "{{ .Values.auth.AZURE_STORAGE_ACCOUNT_KEY }}"

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -101,6 +101,12 @@ auth:
   AZURE_STORAGE_ACCOUNT_KEY: ""
   AZURE_STORAGE_ACCOUNT_NAME: ""
 
+  # External metadata Postgres DSN. Set this to run standalone with Postgres as the
+  # meta store (also set config.ZO_META_STORE: "postgres"). It is a credential, so it
+  # is stored in the Secret, not the ConfigMap. Takes precedence over
+  # config.ZO_META_POSTGRES_DSN if both are set.
+  ZO_META_POSTGRES_DSN: ""
+
 # https://openobserve.ai/docs/environment-variables/
 config:
   ZO_APP_NAME: "openobserve"


### PR DESCRIPTION
The Postgres DSN — a credential — was rendered into the plaintext ConfigMap.

Moves it to the Secret and adds an `auth.ZO_META_POSTGRES_DSN` override that takes precedence over `config.ZO_META_POSTGRES_DSN`, mirroring how the `openobserve` chart already handles it.

Transparent on upgrade: the StatefulSet already consumes the Secret via `envFrom` (after the ConfigMap), and the standalone chart has no `externalSecret` path.

Fixes #221