### PR TITLE
feat: add optional Prometheus Operator ServiceMonitor

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-standalone/templates/servicemonitor.yaml
+++ b/charts/openobserve-standalone/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openobserve.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "openobserve.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "openobserve.selectorLabels" . | nindent 6 }}
+      prometheus.io/scrape: "true"
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | default "10s" }}
+      scheme: {{ .Values.serviceMonitor.scheme | default "http" }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels | default false }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -329,6 +329,21 @@ extraEnv: []
 #       name: s3credentials-secret
 #       key: S3_KEY
 
+# Prometheus Operator ServiceMonitor to scrape OpenObserve's /metrics endpoint.
+# Requires the Prometheus Operator CRDs (monitoring.coreos.com/v1) to be installed.
+serviceMonitor:
+  enabled: false
+  # namespace: ""            # defaults to the release namespace
+  # additionalLabels: {}     # e.g. { release: kube-prometheus-stack } to match your Prometheus selector
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /metrics
+  scheme: http
+  honorLabels: false
+  # tlsConfig: {}
+  relabelings: []
+  metricRelabelings: []
+
 service:
   type: ClusterIP
   # type: LoadBalancer

--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve/templates/servicemonitor.yaml
+++ b/charts/openobserve/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openobserve.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "openobserve.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "openobserve.selectorLabels" . | nindent 6 }}
+      role: router
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | default "10s" }}
+      scheme: {{ .Values.serviceMonitor.scheme | default "http" }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels | default false }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -473,6 +473,21 @@ extraEnv: []
 #       key: S3_KEY
 
 # This is for router
+# Prometheus Operator ServiceMonitor to scrape OpenObserve's /metrics endpoint.
+# Requires the Prometheus Operator CRDs (monitoring.coreos.com/v1) to be installed.
+serviceMonitor:
+  enabled: false
+  # namespace: ""            # defaults to the release namespace
+  # additionalLabels: {}     # e.g. { release: kube-prometheus-stack } to match your Prometheus selector
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /metrics
+  scheme: http
+  honorLabels: false
+  # tlsConfig: {}
+  relabelings: []
+  metricRelabelings: []
+
 service:
   type: ClusterIP
   # type: LoadBalancer


### PR DESCRIPTION
Adds a `ServiceMonitor` template (gated by `serviceMonitor.enabled`, default `false`) to both the `openobserve` and `openobserve-standalone` charts, scraping the `/metrics` path on the `http` service port. Configurable interval, timeout, path, scheme, labels, `tlsConfig`, `relabelings` and `metricRelabelings`.

Selector verification:
- HA: matches `openobserve.selectorLabels` + `role: router` — carried by `router-service.yaml`, which exposes a port named `http`.
- Standalone: matches `openobserve.selectorLabels` + `prometheus.io/scrape: "true"` — carried only by `openobserve-service.yaml`, so the headless service is not double-matched.

Note: on the HA chart this scrapes the router only. Per-role endpoints (ingester/querier/compactor/alertmanager) can follow if wanted.

Fixes #186