### PR TITLE
feat(standalone): optional writable cache emptyDir for read-only rootfs

### DIFF
--- a/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
+++ b/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
@@ -109,6 +109,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            {{- if .Values.cache.enabled }}
+            # Writable cache dir so the app can create its cache when
+            # securityContext.readOnlyRootFilesystem: true. Point
+            # config.ZO_DATA_CACHE_DIR at this same path.
+            - name: cache
+              mountPath: {{ .Values.cache.mountPath }}
+            {{- end }}
           {{- if .Values.extraVolumeMounts }}
           {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
@@ -129,6 +136,16 @@ spec:
         # persistence disabled: back /data with an ephemeral emptyDir instead of a PVC.
         - name: data
           emptyDir: {}
+      {{- end }}
+      {{- if .Values.cache.enabled }}
+        - name: cache
+          emptyDir:
+            {{- if .Values.cache.medium }}
+            medium: {{ .Values.cache.medium | quote }}
+            {{- end }}
+            {{- if .Values.cache.sizeLimit }}
+            sizeLimit: {{ .Values.cache.sizeLimit | quote }}
+            {{- end }}
       {{- end }}
       {{- if .Values.extraVolumes }}
       {{ toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -52,6 +52,17 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Optional writable cache volume. Enable this when running with
+# securityContext.readOnlyRootFilesystem: true so OpenObserve can create its cache
+# directory (otherwise the process panics with a ReadOnlyFilesystem error).
+# NOTE: also set config.ZO_DATA_CACHE_DIR to the same mountPath so the app writes its
+# cache there. Validate the path for your app version before relying on it.
+cache:
+  enabled: false
+  mountPath: /cache
+  # medium: "Memory"   # use a tmpfs-backed emptyDir instead of node disk
+  # sizeLimit: "2Gi"   # optional emptyDir size limit
+
 persistence:
   enabled: true
   size: 10Gi


### PR DESCRIPTION
Adds a `cache` volume option (disabled by default). When enabled it mounts a writable `emptyDir` at `cache.mountPath` so OpenObserve can create its cache directory under `securityContext.readOnlyRootFilesystem: true` instead of panicking with a `ReadOnlyFilesystem` error. Supports `medium` (tmpfs) and `sizeLimit`.

Users should point `config.ZO_DATA_CACHE_DIR` at the same path.

⚠️ **Best-effort** — the panic originates from OpenObserve creating a cache dir under a relative `ZO_DATA_DIR` (`./data/`) resolved against the read-only container workdir. The exact cache path should be validated against a live pod per app version, and there may be additional relative paths the app writes to. Default is off, so this is additive and cannot regress existing installs. Applied to the standalone chart; the HA workloads can follow the same pattern.

Fixes #54