### PR TITLE
docs: add UPGRADING guide, Artifact Hub metadata, and auth-header docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,23 @@ To see the available charts in this repository:
 ```bash
 helm search repo openobserve
 ```
+
+## Deriving the collector Authorization header (CI/CD)
+
+The `openobserve-collector` chart needs an `Authorization` header to ship data to
+OpenObserve. You do **not** need to log into the UI to get it — OpenObserve ingestion uses
+HTTP Basic auth built from the same root credentials you pass to the `openobserve` chart, so
+you can compute it in your pipeline:
+
+```bash
+# Same values you set as auth.ZO_ROOT_USER_EMAIL / auth.ZO_ROOT_USER_PASSWORD
+AUTH_HEADER="Basic $(printf '%s:%s' "$ZO_ROOT_USER_EMAIL" "$ZO_ROOT_USER_PASSWORD" | base64 | tr -d '\n')"
+
+helm upgrade --install o2c openobserve/openobserve-collector \
+  --set exporters."otlphttp/openobserve".endpoint="$O2_ENDPOINT" \
+  --set exporters."otlphttp/openobserve".headers.Authorization="$AUTH_HEADER"
+```
+
+## Upgrading
+
+See [UPGRADING.md](UPGRADING.md) for version-specific upgrade notes and breaking changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,50 @@
+# Upgrading the OpenObserve Helm charts
+
+This document highlights upgrades that need manual attention. If a chart version is
+**not** listed here, upgrading is expected to be a straight `helm upgrade` with no manual
+steps. Chart versions follow [Semantic Versioning](https://semver.org/); a bump in the
+**major** chart version signals a potentially breaking change to the chart itself.
+
+> Tip: always review the rendered diff before applying an upgrade:
+>
+> ```bash
+> helm diff upgrade <release> openobserve/<chart> -f your-values.yaml   # requires the helm-diff plugin
+> ```
+
+## How to read this file
+
+- **App upgrades** — bumping the OpenObserve application (`appVersion`), e.g. `0.9.x → 0.10.x`.
+  Application-level breaking changes (schema/meta-store migrations, renamed env vars) are the
+  application's own; check the [OpenObserve release notes](https://github.com/openobserve/openobserve/releases).
+- **Chart upgrades** — breaking changes to the chart templates/values themselves (renamed
+  values, moved keys, renamed resources).
+
+## Chart changes
+
+### openobserve-standalone — Postgres DSN moved to the Secret
+
+`ZO_META_POSTGRES_DSN` is now rendered into the **Secret** instead of the plaintext ConfigMap,
+and a new `auth.ZO_META_POSTGRES_DSN` takes precedence over `config.ZO_META_POSTGRES_DSN` when
+set. No values change is required — the existing `config.ZO_META_POSTGRES_DSN` is still honored
+and the StatefulSet consumes it via `envFrom`. This is transparent on `helm upgrade`.
+
+### openobserve / openobserve-standalone — cert-manager issuer annotation
+
+The default `ingress.annotations` no longer hardcodes `cert-manager.io/issuer: letsencrypt`.
+- If you rely on the **built-in** Issuer, set `certIssuer.enabled: true` — the annotation is then
+  injected automatically.
+- If you use your **own** `cert-manager.io/cluster-issuer`, just set it under `ingress.annotations`;
+  there is no longer a conflicting `issuer` annotation.
+
+### openobserve-standalone — persistence.enabled now gates the PVC
+
+`persistence.enabled: false` now actually removes the data `volumeClaimTemplate` and backs `/data`
+with an ephemeral `emptyDir`. Previously the PVC was always created. If you were setting
+`persistence.enabled: false` and unknowingly still getting a PVC, you will now get ephemeral
+storage — set it back to `true` if you need the PVC.
+
+## Application upgrades
+
+For OpenObserve application upgrades (the `appVersion` / image tag), always consult the
+upstream release notes for migration steps before upgrading:
+<https://github.com/openobserve/openobserve/releases>.

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,8 @@
+# Artifact Hub repository metadata.
+# https://artifacthub.io/docs/topics/repositories/helm-charts/
+# Place this file at the root of the branch/path that Artifact Hub indexes so the
+# repository can be verified and ownership claimed.
+repositoryID: ""   # fill in with the ID shown in the Artifact Hub control panel after adding the repo
+owners:
+  - name: OpenObserve
+    email: hello@openobserve.ai

--- a/charts/openobserve-collector/Chart.yaml
+++ b/charts/openobserve-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5
+version: 0.4.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,3 +33,20 @@ maintainers:
   - name: OpenObserve
     email: hello@openobserve.ai
     url: https://openobserve.ai
+home: https://openobserve.ai
+icon: https://openobserve.ai/img/logo/logo.svg
+sources:
+  - https://github.com/openobserve/openobserve-helm-chart
+keywords:
+  - openobserve
+  - opentelemetry
+  - otel-collector
+  - observability
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://openobserve.ai/docs/
+    - name: Source
+      url: https://github.com/openobserve/openobserve-helm-chart

--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,3 +33,24 @@ maintainers:
   - name: OpenObserve
     email: hello@openobserve.ai
     url: https://openobserve.ai
+home: https://openobserve.ai
+icon: https://openobserve.ai/img/logo/logo.svg
+sources:
+  - https://github.com/openobserve/openobserve
+  - https://github.com/openobserve/openobserve-helm-chart
+keywords:
+  - openobserve
+  - observability
+  - logs
+  - metrics
+  - traces
+  - rum
+  - elasticsearch
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://openobserve.ai/docs/
+    - name: Source
+      url: https://github.com/openobserve/openobserve-helm-chart

--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.1
+version: 0.91.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -37,3 +37,24 @@ maintainers:
   - name: OpenObserve
     email: hello@openobserve.ai
     url: https://openobserve.ai
+home: https://openobserve.ai
+icon: https://openobserve.ai/img/logo/logo.svg
+sources:
+  - https://github.com/openobserve/openobserve
+  - https://github.com/openobserve/openobserve-helm-chart
+keywords:
+  - openobserve
+  - observability
+  - logs
+  - metrics
+  - traces
+  - rum
+  - elasticsearch
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://openobserve.ai/docs/
+    - name: Source
+      url: https://github.com/openobserve/openobserve-helm-chart


### PR DESCRIPTION
- `UPGRADING.md` documenting version-specific/breaking chart changes (#89)
- Artifact Hub repo metadata (`artifacthub-repo.yml`) plus per-chart `annotations`/`home`/`sources`/`icon`/`keywords` (#185)
- README section on deriving the collector `Authorization` header in CI/CD without logging into the UI (#123)

Chart versions bumped so Artifact Hub actually picks up the new metadata (it indexes on chart version).

Note: claiming the repository on artifacthub.io is a maintainer account action and still needs to be done manually after this lands.

Fixes #89
Fixes #185
Fixes #123