### PR TITLE
fix(ingress): Change metrics matching to be Prefix instead of Exact

### DIFF
--- a/charts/openobserve-standalone/templates/ingress.yaml
+++ b/charts/openobserve-standalone/templates/ingress.yaml
@@ -52,7 +52,7 @@ spec:
           {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
           # Block /metrics endpoint - always blocked for public access
           - path: /metrics
-            pathType: Exact
+            pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}-blocked-metrics
@@ -60,7 +60,7 @@ spec:
                   number: 80
           # Block /api/metrics endpoint - always blocked for public access
           - path: /api/metrics
-            pathType: Exact
+            pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}-blocked-metrics

--- a/charts/openobserve/templates/ingress.yaml
+++ b/charts/openobserve/templates/ingress.yaml
@@ -52,7 +52,7 @@ spec:
           {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
           # Block /metrics endpoint - always blocked for public access
           - path: /metrics
-            pathType: Exact
+            pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}-blocked-metrics
@@ -60,7 +60,7 @@ spec:
                   number: 80
           # Block /api/metrics endpoint - always blocked for public access
           - path: /api/metrics
-            pathType: Exact
+            pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}-blocked-metrics


### PR DESCRIPTION
Some ingress controllers like Tailscale do not support Exact and emit warnings like: `Exact path type strict matching is currently not supported and requests will be routed as for Prefix path type.` I don't believe that this needs to be Exact (Prefix provides a stronger block here), so just changing it here to silence the warning.