### PR TITLE
feat(dex): support extraVolumes/extraVolumeMounts for custom root CAs

### DIFF
--- a/charts/openobserve/templates/dex-deployment.yaml
+++ b/charts/openobserve/templates/dex-deployment.yaml
@@ -75,6 +75,9 @@ spec:
             - name: config
               mountPath: /etc/dex
               readOnly: true
+            {{- with .Values.enterprise.dex.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "openobserve.fullname" . }}
@@ -88,7 +91,10 @@ spec:
         - name: config
           configMap:
             name: {{ include "openobserve.fullname" . }}-dex
-            
+        {{- with .Values.enterprise.dex.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
       {{- with .Values.enterprise.dex.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -996,6 +996,27 @@ enterprise:
       tag: v2.37.0
       pullPolicy: IfNotPresent
     extraEnv: []
+    # Mount additional volumes into the dex pod, e.g. a private root CA for an
+    # OIDC connector (Keycloak). Create a secret with the CA cert and reference
+    # it here, then point the connector's rootCAs at the mounted path:
+    #   connectors:
+    #     - type: oidc
+    #       id: keycloak
+    #       name: Keycloak
+    #       config:
+    #         issuer: https://keycloak.example.com/realms/master
+    #         rootCAs:
+    #           - /etc/dex/certs/ca.crt
+    # extraVolumes:
+    #   - name: keycloak-ca
+    #     secret:
+    #       secretName: keycloak-ca
+    # extraVolumeMounts:
+    #   - name: keycloak-ca
+    #     mountPath: /etc/dex/certs
+    #     readOnly: true
+    extraVolumes: []
+    extraVolumeMounts: []
     ingress:
       enabled: true
       className: "nginx"


### PR DESCRIPTION
Allows mounting a private root CA into the dex pod so OIDC connectors (e.g. Keycloak) can verify issuers signed by an internal CA via rootCAs. Includes a commented Keycloak example in values.yaml.