### PR TITLE
fix(dex): allow ServiceAccount annotations, derive probe path from issuer, default replicaCount.dex

### DIFF
--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.91.2
+version: 0.91.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve/templates/dex-deployment.yaml
+++ b/charts/openobserve/templates/dex-deployment.yaml
@@ -40,10 +40,16 @@ spec:
             - containerPort: 5556
               name: http
           {{- if .Values.probes.dex.enabled }}
+          {{- /*
+            dex registers every handler under the path of its issuer URL, so an
+            issuer of https://o2.example.com/dex serves health at /dex/healthz.
+            Derive the path from the issuer instead of assuming the root.
+          */}}
+          {{- $dexHealthPath := clean (printf "%s/healthz" (urlParse .Values.enterprise.dex.config.issuer).path) }}
           livenessProbe:
             httpGet:
-              path: /healthz
-              port: {{ .Values.config.ZO_HTTP_PORT }}
+              path: {{ $dexHealthPath }}
+              port: http
             initialDelaySeconds: {{ .Values.probes.dex.config.livenessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.probes.dex.config.livenessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.probes.dex.config.livenessProbe.timeoutSeconds | default 10 }}
@@ -52,8 +58,8 @@ spec:
             terminationGracePeriodSeconds: {{ .Values.probes.dex.config.livenessProbe.terminationGracePeriodSeconds | default 30 }}
           readinessProbe:
             httpGet:
-              path: /healthz
-              port: {{ .Values.config.ZO_HTTP_PORT }}
+              path: {{ $dexHealthPath }}
+              port: http
             initialDelaySeconds: {{ .Values.probes.dex.config.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.probes.dex.config.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.probes.dex.config.readinessProbe.timeoutSeconds | default 10 }}
@@ -61,8 +67,8 @@ spec:
             failureThreshold: {{ .Values.probes.dex.config.readinessProbe.failureThreshold | default 3 }}
           startupProbe:
             httpGet:
-              path: /healthz
-              port: {{ .Values.config.ZO_HTTP_PORT }}
+              path: {{ $dexHealthPath }}
+              port: http
             initialDelaySeconds: {{ .Values.probes.dex.config.startupProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.probes.dex.config.startupProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.probes.dex.config.startupProbe.timeoutSeconds | default 10 }}

--- a/charts/openobserve/templates/dex-serviceaccount.yaml
+++ b/charts/openobserve/templates/dex-serviceaccount.yaml
@@ -4,5 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "openobserve.fullname" . }}-dex
   namespace: {{ .Release.Namespace | quote }}
+  {{- with (.Values.enterprise.dex.serviceAccount | default dict).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -75,6 +75,7 @@ replicaCount:
   compactor: 1
   reportserver: 0
   o2ai: 2
+  dex: 1
 
 alertmanager:
   extraEnv: []
@@ -913,6 +914,12 @@ enterprise:
       pullPolicy: IfNotPresent
   dex:
     enabled: false
+    serviceAccount:
+      # Annotations for the dex ServiceAccount. Required for cloud workload
+      # identity, e.g. letting the google connector reach the Admin SDK
+      # Directory API without mounting a static service account key:
+      #   iam.gke.io/gcp-service-account: dex-dwd@my-project.iam.gserviceaccount.com
+      annotations: {}
     parameters:
       O2_CALLBACK_URL: https://openobserve.example.com/web/cb
       O2_DEX_SCOPES: openid profile email groups offline_access


### PR DESCRIPTION
## Summary

Three independent fixes for the bundled dex deployment. They are unrelated to each other — happy to split into separate PRs if you prefer.

### 1. The dex ServiceAccount cannot carry annotations

`dex-serviceaccount.yaml` renders no `annotations`, and `serviceAccountName` in `dex-deployment.yaml` is hardcoded to `<fullname>-dex`, so there is currently no way to attach cloud workload identity to the dex pod.

This blocks group resolution with the google connector. Fetching groups needs Admin SDK Directory API access, and dex >= v2.40.0 can do that **without a static service account key**: when `serviceAccountFilePath` is empty and the default credential has no JSON (i.e. a metadata server), it impersonates through `impersonate.CredentialsConfig{TargetPrincipal, Subject}` — see `createServiceWithMetadataServer` in [`connector/google/google.go`](https://github.com/dexidp/dex/blob/v2.45.1/connector/google/google.go). That path only works when the KSA carries the provider annotation, e.g. `iam.gke.io/gcp-service-account` on GKE.

Without this, the options are mounting a long-lived SA key through `extraVolumes`, or patching the rendered ServiceAccount out of band — the latter conflicts with GitOps tools that own the object.

Adds `enterprise.dex.serviceAccount.annotations` (defaults to `{}`, so nothing changes for existing users).

### 2. dex probes target the wrong port and the wrong path

**Port** — probes use `config.ZO_HTTP_PORT` (5080, the OpenObserve port) while dex listens on 5556. Enabling `probes.dex.enabled` makes the pod fail every check immediately. They now use the named `http` port already declared on the container.

**Path** — probes assume `/healthz` at the root, but dex registers every handler under the path of its issuer URL (`server.go` joins `issuerURL.Path` into each route). With the chart's own default issuer `https://dex.example.com/dex`, health actually lives at `/dex/healthz`, so even the port fix alone would not be enough. The path is now derived from the configured issuer:

```
{{- $dexHealthPath := clean (printf "%s/healthz" (urlParse .Values.enterprise.dex.config.issuer).path) }}
```

An issuer with no path yields `/healthz`, and a trailing slash is normalised by `clean`.

### 3. `replicaCount.dex` has no default

`dex-deployment.yaml` reads `.Values.replicaCount.dex`, but `values.yaml` has no `dex` key under `replicaCount`, so it renders `replicas: ` (null). Adds a default of `1`.

## Testing

Rendered with `helm template` in both configurations:

- **dex disabled (chart default)** — no dex resources emitted, output identical to before the change.
- **dex enabled** with `probes.dex.enabled=true`, `issuer: https://o2.example.com/dex`, and an SA annotation:

```yaml
# ServiceAccount
metadata:
  name: t-openobserve-dex
  annotations:
    iam.gke.io/gcp-service-account: dex-dwd@example.iam.gserviceaccount.com

# Deployment
replicas: 1
livenessProbe.httpGet:  {"path": "/dex/healthz", "port": "http"}
readinessProbe.httpGet: {"path": "/dex/healthz", "port": "http"}
startupProbe.httpGet:   {"path": "/dex/healthz", "port": "http"}
```

Also verified against a live deployment: dex v2.45.1 behind an issuer of `https://<host>/dex` serves discovery at `/dex/.well-known/openid-configuration` and health at `/dex/healthz`, confirming the path derivation.

Chart version bumped 0.91.2 → 0.91.3 — let me know if you'd rather handle version bumps at release time and I'll drop that commit.
